### PR TITLE
fixed spelling of 'summery' to 'summary' to be in line with hRecipe stand

### DIFF
--- a/background.html
+++ b/background.html
@@ -36,7 +36,7 @@
 	function processData(data) {
 		var currentURL = "";
 		//debug		
-		var toString = "rec-name:"+ data.$recName + " ingrediants:"+ data.$ingredients + " yield:" + data.$yield;
+		var toString = "rec-name:"+ data.$recName + " ingredients:"+ data.$ingredients + " yield:" + data.$yield;
 		debug("got data:  "+toString)
 
 		var hRecipeCode = convertTohRecipe(data);

--- a/background.html
+++ b/background.html
@@ -74,7 +74,7 @@
 			if(data.$photos.length>0 && data.$photos[0].length > 0) {
 				microformat += ("<img src=\"" + data.$photos[0] + "\" class=\"photo\" style=\"height:140px;width:140px;border-width:0px;\" alt=\"" + data.$recName + "\">\n");
 			}
-			if(data.$summery) microformat += ("<p class=\"summery\">" + data.$summery + "</p>\n");
+			if(data.$summary) microformat += ("<p class=\"summary\">" + data.$summary + "</p>\n");
 			microformat +="<h2>Ingredients</h2>\n";
 			microformat +="<ul>\n";
 			for(var i in data.$ingredients) {

--- a/js/formData.js
+++ b/js/formData.js
@@ -12,7 +12,7 @@ function FormData() {
 	this.$cooktime = 0;
 	this.$preptime = 0;
 	this.$photos  = [];
-	this.$summery = "";
+	this.$summary = "";
 	this.$authors = [];
 	this.$published = "";
 	this.$nutritions = [];

--- a/js/hRecipeHelper.js
+++ b/js/hRecipeHelper.js
@@ -89,7 +89,7 @@
 			   minlength: jQuery.format("At least {0} characters required!")
 			 },
 			 ingredient0: {
-			   required: "Requires 1 ingrediant.",
+			   required: "Requires 1 ingredient.",
 			   minlength: jQuery.format("At least {0} characters required!")
 			 }			 
 		   },

--- a/js/hRecipeHelper.js
+++ b/js/hRecipeHelper.js
@@ -176,7 +176,7 @@
 			clearArrayFields('nutrition');
 		}
 
-		$('#summery').val(formData.$summery);
+		$('#summary').val(formData.$summary);
 		var tagStrings = (formData.$tags)? formData.$tags.join():''; 
 		$('#tag').val(tagStrings);		
 	}	
@@ -237,7 +237,7 @@
 		formData.$nutritionTypes = $("[id^=nutritionType]").map(function(){return $(this).val();}).get();
 		formData.$nutritions = getFormArray('nutrition');
 		debug('nutrition==' + formData.$nutritions.toString());
-		formData.$summery = $('#summery').val();
+		formData.$summary = $('#summary').val();
 		formData.$tags = $('#tag').val().split(',');
 		
 		debug("formData.nTypes="+ formData.$nutritionTypes );

--- a/popup.html
+++ b/popup.html
@@ -28,7 +28,7 @@
 			<tr><th><label for="author">Author</label></th><td><input type="text" id="author" name="author"  class="large-field"/></div></td></tr>
 			<tr><th><label for="published">Published</label></th><td><input type="text" id="published" name="published"/></td></tr>
 			<tr><th><label for="yield">Yield</label></th><td><input type="text" id="yield" name="yield"/></td></tr>
-			<tr><th><label for="summary">Summery</label></th><td><textarea id="summary" name="summary" rows="3" cols="30"></textarea></td></tr>
+			<tr><th><label for="summary">Summary</label></th><td><textarea id="summary" name="summary" rows="3" cols="30"></textarea></td></tr>
 			<tr><th><label for="ingredient">Ingredients </label></th><td><a href="#" onClick="addFormField('ingredient'); return false;">add</a></td><tr>
 			<tr><td colspan=2>
 			<ul id='ingredientList'>

--- a/popup.html
+++ b/popup.html
@@ -28,7 +28,7 @@
 			<tr><th><label for="author">Author</label></th><td><input type="text" id="author" name="author"  class="large-field"/></div></td></tr>
 			<tr><th><label for="published">Published</label></th><td><input type="text" id="published" name="published"/></td></tr>
 			<tr><th><label for="yield">Yield</label></th><td><input type="text" id="yield" name="yield"/></td></tr>
-			<tr><th><label for="summery">Summery</label></th><td><textarea id="summery" name="summery" rows="3" cols="30"></textarea></td></tr>
+			<tr><th><label for="summary">Summery</label></th><td><textarea id="summary" name="summary" rows="3" cols="30"></textarea></td></tr>
 			<tr><th><label for="ingredient">Ingredients </label></th><td><a href="#" onClick="addFormField('ingredient'); return false;">add</a></td><tr>
 			<tr><td colspan=2>
 			<ul id='ingredientList'>


### PR DESCRIPTION
Hi, I was looking into hRecipe this evening and came across your plugin. I tried entering a recipe but noticed that the markup you were generating and the label for the "Summary" field read as "summery". This commit should fix that. 

One thing to note, I'm not sure how to test the chrome plugin locally but I took a peek at the source and it seems like I caught all the references when I did the replacement.

*\* edit: I added a couple more commits here as I figured out how to test the plugin in chrome to make sure it was working properly. Also found "ingrediant" and replaced with "ingredient" :)
